### PR TITLE
Optional viruses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,7 @@
 # Changelog for ndx-optogenetics
+
+# v0.2.1 (Upcoming)
+
+## Improvements
+
+- Made the `OptogeneticViruses` and `OptogeneticVirusInjections` groups optional for the `OptogeneticExperimentMetadata` group [PR #5](https://github.com/rly/ndx-optogenetics/pull/5).

--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ Because this type extends the `DynamicTable` class, you can add new columns to i
 #### OptogeneticExperimentMetadata
 Container for all optogenetics-related metadata including:
 - `OpticalFiberLocationsTable`
-- Collection of `OptogeneticVirus` objects
-- Collection of `OptogeneticVirusInjection` objects
+- Collection of `OptogeneticVirus` objects (optional)
+- Collection of `OptogeneticVirusInjection` objects (optional)
 - `stimulation_software`: Name of software used for stimulation
 
 You can define extensions to this ndx-optogenetics extension to store additional metadata in a structured

--- a/spec/ndx-optogenetics.extensions.yaml
+++ b/spec/ndx-optogenetics.extensions.yaml
@@ -283,9 +283,11 @@ groups:
   - name: optogenetic_viruses
     neurodata_type_inc: OptogeneticViruses
     doc: Group containing of one or more OptogeneticVirus objects.
+    quantity: '?'
   - name: optogenetic_virus_injections
     neurodata_type_inc: OptogeneticVirusInjections
     doc: Group containing one or more OptogeneticVirusInjection objects.
+    quantity: '?'
 - neurodata_type_def: OptogeneticEpochsTable
   neurodata_type_inc: TimeIntervals
   doc: General metadata about the optogenetic stimulation that may change per epoch.

--- a/src/spec/create_extension_spec.py
+++ b/src/spec/create_extension_spec.py
@@ -547,11 +547,13 @@ def main():
                 name="optogenetic_viruses",
                 neurodata_type_inc="OptogeneticViruses",
                 doc="Group containing of one or more OptogeneticVirus objects.",
+                quantity="?",
             ),
             NWBGroupSpec(
                 name="optogenetic_virus_injections",
                 neurodata_type_inc="OptogeneticVirusInjections",
                 doc="Group containing one or more OptogeneticVirusInjection objects.",
+                quantity="?",
             ),
         ],
     )


### PR DESCRIPTION
Fixes #3

This PR makes the `OptogeneticViruses` and `OptogeneticVirusInjections` groups optional for the `OptogeneticExperimentMetadata` group. 