### PR TITLE
Updated ndx_ophys_devices version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # v0.3.0 (Upcoming)
 
 - Refactored the extension to depend on ndx-ophys-devices for device and biological component specification, replacing its previous standalone device types. Introduced the OptogeneticSitesTable to consolidate stimulation site metadata (excitation source, optical fiber, effector), updated the schema, API, docs, and tests accordingly, and improved modularity for optogenetic metadata. [PR #9](https://github.com/rly/ndx-optogenetics/pull/9)
+- Updated requirements to depend on ndx-ophys-devices>=0.3.1 [PR #14](https://github.com/rly/ndx-optogenetics/pull/14)
 
 # v0.2.1 (Upcoming)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ keywords = [
 dependencies = [
     "pynwb>=3.1.0",
     "hdmf>=4.1.0",
-    "ndx_ophys_devices>=0.3.0",
+    "ndx_ophys_devices>=0.3.1",
 ]
 
 [project.optional-dependencies]
@@ -64,7 +64,7 @@ dev = [
 min-reqs = [
     "pynwb==3.1.0",
     "hdmf==4.1.0",
-    "ndx_ophys_devices==0.3.0",
+    "ndx_ophys_devices==0.3.1",
 ]
 
 # TODO: add URLs before release


### PR DESCRIPTION
This PR updates the dependency to use the latest version of ndx-ophys-devices (0.3.1) which fixes the namespace bug that I introduced previously with 0.3.0. For details, see https://github.com/catalystneuro/ndx-ophys-devices/pull/21